### PR TITLE
Update to 1.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,17 +14,21 @@ env:
     - secure: "ICuLmr3ccqMISceKLpkB/iClfX3UZTYb2+3ZKNdfAS9+5v7gGavNJskuo7UW4q8aNvz+ZzUDNJiEtPr3BI7RWTPrqkZMOuTERAH8LNH8wH3TbrFOXGOOHC7J4Ts1QztSNvtkyEdqdEdG+0UAWIfgRq9UX5WQ3luwg8IA26IXpxPiWSdU3cSetAL0UWfP95EYukeUtYsyHjtHtZSPj/akqJ985I/OirRWoDctWSgq0mSbybHggb2jXCIA9Hk+eBVMX8S4KMNNT89VRWms31estZKE2QrxqVLlCZObUrNsHYlcf1bc4fOa3lJqQ8hQ+wi4A4vKWnFH/w24YQ1RDErECdK2zBroSGs4ENlwIq6idDCHdXBa02eppHSUXDbfEvVPE0/kOqtTdLjsEKpdEl2KQ4ql6zQwHm90piEiO6ycUymftLVTnXiTzuaLqCyhi/SlCYVcROIDKZ509NB78YWvrP6bPElwQGIflxIqU4JXsmj/V+c62W2XB7lDoPYb8C9VF/MJBI5rkNOAb/x568TSXxGr3cp458yjesMNhjhjAIk8BuJHHAoRpq16qQaqeRKLP73YJ6rg9XINUlOicUimhaHHokMtORUbDyyjdvT/geO/M/oXdkJOFAZXwHEBHhZ5ix99olGjHJOMvunapHDVbFieWTU0tXSm2HRITxPxJkw="
 
 
+before_install:
+    - brew remove --force $(brew list)
+
 install:
     - |
       MINICONDA_URL="http://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
-      wget "${MINICONDA_URL}/${MINICONDA_FILE}"
+      curl -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
       export PATH=/Users/travis/miniconda3/bin:$PATH
 
+      conda config --set show_channel_urls true
       conda update --yes conda
-      conda install --yes conda-build jinja2 anaconda-client
+      conda install --yes conda-build=1.20.0 jinja2 anaconda-client
       conda config --add channels conda-forge
       
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Home: https://github.com/pypa/setuptools_scm/
 
 Package license: MIT
 
-Feedstock license: BSD
+Feedstock license: BSD 3-Clause
 
 Summary: The blessed package to manage your versions by scm tags
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -59,10 +59,15 @@ install:
     - cmd: set PATH=%CONDA_INSTALL_LOCN%;%CONDA_INSTALL_LOCN%\scripts;%PATH%
     - cmd: set PYTHONUNBUFFERED=1
 
+    - cmd: conda config --set show_channel_urls true
     - cmd: conda install -c http://conda.binstar.org/pelson/channel/development --yes --quiet obvious-ci
     - cmd: conda config --add channels http://conda.binstar.org/conda-forge
     - cmd: conda info
     - cmd: conda install -n root --quiet --yes conda-build anaconda-client jinja2 setuptools
+    # Workaround for Python 3.4 and x64 bug in latest conda-build.
+    # FIXME: Remove once there is a release that fixes the upstream issue
+    # ( https://github.com/conda/conda-build/issues/895 ).
+    - cmd: if "%TARGET_ARCH%" == "x64" if "%CONDA_PY%" == "34" conda install conda-build=1.20.0 --yes
 
 # Skip .NET project specific build phase.
 build: off

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -20,7 +20,7 @@ channels:
 conda-build:
  root-dir: /feedstock_root/build_artefacts
 
-show_channel_urls: True
+show_channel_urls: true
 
 CONDARC
 )

--- a/recipe/bld.bat
+++ b/recipe/bld.bat
@@ -1,2 +1,0 @@
-"%PYTHON%" setup.py install --single-version-externally-managed --record record.txt
-if errorlevel 1 exit 1

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,11 +1,13 @@
+{% set version = "1.11.0" %}
+
 package:
     name: setuptools_scm
-    version: 1.8.0
+    version: {{ version }}
 
 source:
-    fn: setuptools_scm-1.8.0.tar.bz2
-    url: https://pypi.python.org/packages/source/s/setuptools_scm/setuptools_scm-1.8.0.tar.bz2
-    md5: 49e83e8fee9ac1d356a634707a62e294
+    fn: setuptools_scm-{{ version }}.tar.gz
+    url: https://pypi.python.org/packages/source/s/setuptools_scm/setuptools_scm-{{ version }}.tar.gz
+    md5: 4c5c896ba52e134bbc3507bac6400087
 
 build:
     number: 0


### PR DESCRIPTION
```
v1.11.0
=======

* always run tag_to_version so in order to handle prefixes on old setuptools
  (thanks to Brian May)
* drop support for python 3.2
* extend the error message on missing scm metadata
  (thanks Markus Unterwaditzer)
* fix bug when using callable version_scheme
  (thanks Esben Haabendal)

v1.10.1
=======

* fix issue #73 - in hg pre commit merge, consider parent1 instead of failing

v1.10.0
=======

* add support for overriding the version number via the
  environment variable SETUPTOOLS_SCM_PRETEND_VERSION

* fix isssue #63 by adding the --match parameter to the git describe call
  and prepare the possibility of passing more options to scm backends

* fix issue #70 and #71 by introducing the parse keyword
  to specify custom scm parsing, its an expert feature,
  use with caution

  this change also introduces the setuptools_scm.parse_scm_fallback
  entrypoint which can be used to register custom archive fallbacks


v1.9.0
======

* Add :code:`relative_to` parameter to :code:`get_version` function;
  fixes #44 per #45.
```