### PR TITLE
Added setuptools as a run dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -10,7 +10,7 @@ source:
     md5: 4d19b2bc9580016d991f665ac20e2e8f
 
 build:
-    number: 0
+    number: 1
     script: python setup.py install --single-version-externally-managed --record record.txt
 
 requirements:
@@ -19,6 +19,7 @@ requirements:
         - setuptools
     run:
         - python
+        - setuptools
 
 test:
     imports:


### PR DESCRIPTION
I kept getting "ImportError: No module named pkg_resources" at the test step when trying to build setuptools_scm using this recipe (specifically from the call to import setuptools_scm).
From searching around, it seems like pkg_resources is a module provided by setuptools, and so I believe that means that setuptools should be a run dependency for setuptools_scm.
Adding setuptools to the list of run dependencies certainly resolved the issue I was having, at any rate.