### PR TITLE
Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Package license: MIT
 
 Feedstock license: BSD 3-Clause
 
-Summary: The blessed package to manage your versions by scm tags
+Summary: The blessed package to manage your versions by scm tags.
 
 
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -58,6 +58,16 @@ install:
     - cmd: rmdir C:\cygwin /s /q
     - appveyor DownloadFile "https://raw.githubusercontent.com/pelson/Obvious-CI/master/bootstrap-obvious-ci-and-miniconda.py"
     - cmd: python bootstrap-obvious-ci-and-miniconda.py %CONDA_INSTALL_LOCN% %TARGET_ARCH% %CONDA_PY:~0,1% --without-obvci
+
+    # Add a hack to switch to `conda` version `4.1.12` before activating.
+    # This is required to handle a long path activation issue.
+    # Please see PR ( https://github.com/conda/conda/pull/3349 ).
+    - cmd: set "OLDPATH=%PATH%"
+    - cmd: set "PATH=%CONDA_INSTALL_LOCN%\\Scripts;%CONDA_INSTALL_LOCN%\\Library\\bin;%PATH%"
+    - cmd: conda install --yes --quiet conda=4.1.12
+    - cmd: set "PATH=%OLDPATH%"
+    - cmd: set "OLDPATH="
+
     - cmd: call %CONDA_INSTALL_LOCN%\Scripts\activate.bat
     - cmd: set PYTHONUNBUFFERED=1
 

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -1,4 +1,4 @@
-{% set version = "1.13.1" %}
+{% set version = "1.15.0" %}
 
 package:
   name: setuptools_scm
@@ -6,8 +6,8 @@ package:
 
 source:
   fn: setuptools_scm-{{ version }}.tar.gz
-  url: https://github.com/pypa/setuptools_scm/archive/v{{ version }}.tar.gz
-  sha256: 295dd25103311c6627991d652e7dd6fd9f5ad61742a32dd829e92d30e0f2889b
+  url: https://github.com/pypa/setuptools_scm/archive/{{ version }}.tar.gz
+  sha256: 9865a6b40e11dc3f4e4020110cd42b9e9cab04be9fc855984fcb4bbdbc8c5d1e
 
 build:
   number: 0


### PR DESCRIPTION
```
v1.15.0
=======

* more sophisticated ignoring of mercurial tag commits
  when considering distance in commits
  (thanks Petre Mierlutiu)
* fix issue #114: stop trying to be smart for the sdist
  and ensure its always correctly usign itself
* update trove classifiers
* fix issue #84: document using the installed package metadata for sphinx
* fix issue #81: fail more gracious when git/hg are missing
* address issue #93: provide an experimental api to customize behaviour on shallow git repos
  a custom parse function may pick pre parse actions to do when using git


v1.14.1
=======

* fix #109: when detecting a dirty git workdir
            don't consider untracked file
            (this was a regression due to #86 in v1.13.1)
* consider the distance 0 when the git node is unknown
  (happens when you haven't commited anything)

v1.14.0
=======

* publish bdist_egg for python 2.6, 2.7 and 3.3-3.5
* fix issue #107 - dont use node if it is None
```